### PR TITLE
Add hotfixes for short polynomials

### DIFF
--- a/src/ceno_binding/pcs.rs
+++ b/src/ceno_binding/pcs.rs
@@ -90,7 +90,7 @@ impl<E: FftField> WhirSpec<E> for WhirDefaultSpec {
             initial_statement: true,
             security_level: 100,
             pow_bits: default_max_pow(num_variables, 1),
-            folding_factor: 2,
+            folding_factor: 4,
             leaf_hash_params,
             two_to_one_params,
             soundness_type: SoundnessType::ConjectureList,

--- a/src/poly_utils/coeffs.rs
+++ b/src/poly_utils/coeffs.rs
@@ -34,6 +34,14 @@ where
         self.coeffs[index]
     }
 
+    pub fn pad_to_num_vars(&mut self, num_vars: usize) {
+        if self.num_variables < num_vars {
+            let pad = (1usize << num_vars) - (1usize << self.num_variables);
+            self.coeffs.extend(vec![F::ZERO; pad]);
+            self.num_variables = num_vars;
+        }
+    }
+
     /// Linearly combine the given polynomials using the given coefficients
     pub fn combine(polys: &[Self], coeffs: &[F]) -> Self {
         Self::new(
@@ -179,7 +187,7 @@ impl<F> CoefficientList<F> {
 
     /// Map the polynomial `self` from F[X_1,...,X_n] to E[X_1,...,X_n], where E is a field extension of F.
     ///
-    /// NOte that this is currently restricted to the case where F is a prime field.
+    /// Note that this is currently restricted to the case where F is a prime field.
     pub fn to_extension<E: Field<BasePrimeField = F>>(self) -> CoefficientList<E> {
         CoefficientList::new(
             self.coeffs

--- a/src/whir/committer.rs
+++ b/src/whir/committer.rs
@@ -50,12 +50,15 @@ where
     pub fn commit<Merlin>(
         &self,
         merlin: &mut Merlin,
-        polynomial: CoefficientList<F::BasePrimeField>,
+        mut polynomial: CoefficientList<F::BasePrimeField>,
     ) -> ProofResult<Witness<F, MerkleConfig>>
     where
         Merlin: FieldWriter<F> + FieldChallenges<F> + ByteWriter + DigestWriter<MerkleConfig>,
     {
         let timer = start_timer!(|| "Single Commit");
+        // If size of polynomial < folding factor, keep doubling polynomial size by cloning itself
+        polynomial.pad_to_num_vars(self.0.folding_factor);
+
         let base_domain = self.0.starting_domain.base_domain.unwrap();
         let expansion = base_domain.size() / polynomial.num_coeffs();
         let evals = expand_from_coeff(polynomial.coeffs(), expansion);

--- a/src/whir/mod.rs
+++ b/src/whir/mod.rs
@@ -122,7 +122,7 @@ mod tests {
 
     #[test]
     fn test_whir() {
-        let folding_factors = [1, 2, 3, 4];
+        let folding_factors = [2, 3, 4, 5];
         let soundness_type = [
             SoundnessType::ConjectureList,
             SoundnessType::ProvableList,
@@ -133,7 +133,7 @@ mod tests {
         let pow_bits = [0, 5, 10];
 
         for folding_factor in folding_factors {
-            let num_variables = folding_factor..=3 * folding_factor;
+            let num_variables = folding_factor - 1..= 2 * folding_factor;
             for num_variables in num_variables {
                 for fold_type in fold_types {
                     for num_points in num_points {

--- a/src/whir/parameters.rs
+++ b/src/whir/parameters.rs
@@ -64,7 +64,7 @@ where
     MerkleConfig: Config,
 {
     pub fn new(
-        mv_parameters: MultivariateParameters<F>,
+        mut mv_parameters: MultivariateParameters<F>,
         whir_parameters: WhirParameters<MerkleConfig, PowStrategy>,
     ) -> Self {
         // We need to fold at least some time
@@ -72,8 +72,10 @@ where
             whir_parameters.folding_factor > 0,
             "folding factor should be non zero"
         );
-        // If less, just send the damn polynomials
-        assert!(mv_parameters.num_variables >= whir_parameters.folding_factor);
+        // Pad the number of variables to folding factor
+        if mv_parameters.num_variables < whir_parameters.folding_factor {
+            mv_parameters.num_variables = whir_parameters.folding_factor
+        }
 
         let protocol_security_level =
             0.max(whir_parameters.security_level - whir_parameters.pow_bits);

--- a/src/whir/prover.rs
+++ b/src/whir/prover.rs
@@ -69,7 +69,7 @@ where
     pub fn prove<Merlin>(
         &self,
         merlin: &mut Merlin,
-        statement: Statement<F>,
+        mut statement: Statement<F>,
         witness: Witness<F, MerkleConfig>,
     ) -> ProofResult<WhirProof<MerkleConfig, F>>
     where
@@ -80,6 +80,13 @@ where
             + PoWChallenge
             + DigestWriter<MerkleConfig>,
     {
+        // If any evaluation point is shorter than the folding factor, pad with 0 in front
+        for p in statement.points.iter_mut() {
+            while p.n_variables() < self.0.folding_factor {
+                p.0.insert(0, F::ONE);
+            }
+        }
+
         assert!(self.validate_parameters());
         assert!(self.validate_statement(&statement));
         assert!(self.validate_witness(&witness));

--- a/src/whir/verifier.rs
+++ b/src/whir/verifier.rs
@@ -325,11 +325,17 @@ where
                 .collect(),
         );
 
+        let statment_points: Vec<MultilinearPoint<F>> = statement.points.clone().into_iter().map(|mut p| {
+            while p.n_variables() < self.params.folding_factor {
+                p.0.insert(0, F::ONE);
+            }
+            p
+        }).collect();
         let mut value = parsed_commitment
             .ood_points
             .iter()
             .map(|ood_point| MultilinearPoint::expand_from_univariate(*ood_point, num_variables))
-            .chain(statement.points.clone())
+            .chain(statment_points)
             .zip(&proof.initial_combination_randomness)
             .map(|(point, randomness)| *randomness * eq_poly_outside(&point, &folding_randomness))
             .sum();

--- a/src/whir/verifier.rs
+++ b/src/whir/verifier.rs
@@ -4,8 +4,8 @@ use ark_crypto_primitives::merkle_tree::Config;
 use ark_ff::FftField;
 use ark_poly::EvaluationDomain;
 use nimue::{
-    plugins::ark::{FieldChallenges, FieldReader}
-    , ByteChallenges, ByteReader, ProofError, ProofResult,
+    plugins::ark::{FieldChallenges, FieldReader},
+    ByteChallenges, ByteReader, ProofError, ProofResult,
 };
 use nimue_pow::{self, PoWChallenge};
 
@@ -106,7 +106,12 @@ where
         whir_proof: &WhirProof<MerkleConfig, F>,
     ) -> ProofResult<ParsedProof<F>>
     where
-        Arthur: FieldReader<F> + FieldChallenges<F> + PoWChallenge + ByteReader + ByteChallenges + DigestReader<MerkleConfig>,
+        Arthur: FieldReader<F>
+            + FieldChallenges<F>
+            + PoWChallenge
+            + ByteReader
+            + ByteChallenges
+            + DigestReader<MerkleConfig>,
     {
         let mut sumcheck_rounds = Vec::new();
         let mut folding_randomness: MultilinearPoint<F>;
@@ -325,17 +330,22 @@ where
                 .collect(),
         );
 
-        let statment_points: Vec<MultilinearPoint<F>> = statement.points.clone().into_iter().map(|mut p| {
-            while p.n_variables() < self.params.folding_factor {
-                p.0.insert(0, F::ONE);
-            }
-            p
-        }).collect();
+        let statement_points: Vec<MultilinearPoint<F>> = statement
+            .points
+            .clone()
+            .into_iter()
+            .map(|mut p| {
+                while p.n_variables() < self.params.folding_factor {
+                    p.0.insert(0, F::ONE);
+                }
+                p
+            })
+            .collect();
         let mut value = parsed_commitment
             .ood_points
             .iter()
             .map(|ood_point| MultilinearPoint::expand_from_univariate(*ood_point, num_variables))
-            .chain(statment_points)
+            .chain(statement_points)
             .zip(&proof.initial_combination_randomness)
             .map(|(point, randomness)| *randomness * eq_poly_outside(&point, &folding_randomness))
             .sum();
@@ -475,7 +485,12 @@ where
         whir_proof: &WhirProof<MerkleConfig, F>,
     ) -> ProofResult<MerkleConfig::InnerDigest>
     where
-        Arthur: FieldChallenges<F> + FieldReader<F> + ByteChallenges + ByteReader + PoWChallenge + DigestReader<MerkleConfig>,
+        Arthur: FieldChallenges<F>
+            + FieldReader<F>
+            + ByteChallenges
+            + ByteReader
+            + PoWChallenge
+            + DigestReader<MerkleConfig>,
     {
         // We first do a pass in which we rederive all the FS challenges
         // Then we will check the algebraic part (so to optimise inversions)


### PR DESCRIPTION
Allow WHIR to process polynomials shorter than the folding factor. This is achieved by padding the short polynomial until it reaches 2^(folding_factor)