### PR TITLE
Batching polynomials of the same size on different points

### DIFF
--- a/src/ceno_binding/merkle_config.rs
+++ b/src/ceno_binding/merkle_config.rs
@@ -6,6 +6,7 @@ use nimue_pow::PowStrategy;
 use crate::crypto::merkle_tree::blake3::MerkleTreeParams as Blake3Params;
 use crate::crypto::merkle_tree::keccak::MerkleTreeParams as KeccakParams;
 use crate::poly_utils::coeffs::CoefficientList;
+use crate::poly_utils::MultilinearPoint;
 use crate::whir::batch::{WhirBatchIOPattern, Witnesses};
 use crate::whir::committer::{Committer, Witness};
 use crate::whir::fs_utils::DigestWriter;
@@ -127,8 +128,8 @@ impl<F: FftField> WhirMerkleConfigWrapper<F> for Blake3ConfigWrapper<F> {
         evals: &[F],
         witness: &Witnesses<F, Self::MerkleConfig>,
     ) -> ProofResult<WhirProof<Self::MerkleConfig, F>> {
-        panic!("batched opening not supported!")
-        // prover.simple_batch_prove(merlin, point, evals, witness)
+        let points = [MultilinearPoint(point.to_vec())];
+        prover.simple_batch_prove(merlin, &points, &[evals.to_vec()], witness)
     }
 
     fn verify_with_arthur(
@@ -147,8 +148,8 @@ impl<F: FftField> WhirMerkleConfigWrapper<F> for Blake3ConfigWrapper<F> {
         evals: &[F],
         whir_proof: &WhirProof<Self::MerkleConfig, F>,
     ) -> ProofResult<<Self::MerkleConfig as Config>::InnerDigest> {
-        panic!("batched opening not supported!")
-        // verifier.simple_batch_verify(arthur, point, evals, whir_proof)
+        let points = [MultilinearPoint(point.to_vec())];
+        verifier.simple_batch_verify(arthur, evals.len(), &points, &[evals.to_vec()], whir_proof)
     }
 
     fn commit_statement_to_io_pattern(
@@ -224,8 +225,8 @@ impl<F: FftField> WhirMerkleConfigWrapper<F> for KeccakConfigWrapper<F> {
         evals: &[F],
         witness: &Witnesses<F, Self::MerkleConfig>,
     ) -> ProofResult<WhirProof<Self::MerkleConfig, F>> {
-        panic!("batched opening not supported!")
-        // prover.simple_batch_prove(merlin, point, evals, witness)
+        let points = [MultilinearPoint(point.to_vec())];
+        prover.simple_batch_prove(merlin, &points, &[evals.to_vec()], witness)
     }
 
     fn verify_with_arthur(
@@ -244,8 +245,8 @@ impl<F: FftField> WhirMerkleConfigWrapper<F> for KeccakConfigWrapper<F> {
         evals: &[F],
         whir_proof: &WhirProof<Self::MerkleConfig, F>,
     ) -> ProofResult<<Self::MerkleConfig as Config>::InnerDigest> {
-        panic!("batched opening not supported!")
-        // verifier.simple_batch_verify(arthur, point, evals, whir_proof)
+        let points = [MultilinearPoint(point.to_vec())];
+        verifier.simple_batch_verify(arthur, evals.len(), &points, &[evals.to_vec()], whir_proof)
     }
 
     fn commit_statement_to_io_pattern(

--- a/src/ceno_binding/merkle_config.rs
+++ b/src/ceno_binding/merkle_config.rs
@@ -127,7 +127,8 @@ impl<F: FftField> WhirMerkleConfigWrapper<F> for Blake3ConfigWrapper<F> {
         evals: &[F],
         witness: &Witnesses<F, Self::MerkleConfig>,
     ) -> ProofResult<WhirProof<Self::MerkleConfig, F>> {
-        prover.simple_batch_prove(merlin, point, evals, witness)
+        panic!("batched opening not supported!")
+        // prover.simple_batch_prove(merlin, point, evals, witness)
     }
 
     fn verify_with_arthur(
@@ -146,7 +147,8 @@ impl<F: FftField> WhirMerkleConfigWrapper<F> for Blake3ConfigWrapper<F> {
         evals: &[F],
         whir_proof: &WhirProof<Self::MerkleConfig, F>,
     ) -> ProofResult<<Self::MerkleConfig as Config>::InnerDigest> {
-        verifier.simple_batch_verify(arthur, point, evals, whir_proof)
+        panic!("batched opening not supported!")
+        // verifier.simple_batch_verify(arthur, point, evals, whir_proof)
     }
 
     fn commit_statement_to_io_pattern(
@@ -222,7 +224,8 @@ impl<F: FftField> WhirMerkleConfigWrapper<F> for KeccakConfigWrapper<F> {
         evals: &[F],
         witness: &Witnesses<F, Self::MerkleConfig>,
     ) -> ProofResult<WhirProof<Self::MerkleConfig, F>> {
-        prover.simple_batch_prove(merlin, point, evals, witness)
+        panic!("batched opening not supported!")
+        // prover.simple_batch_prove(merlin, point, evals, witness)
     }
 
     fn verify_with_arthur(
@@ -241,7 +244,8 @@ impl<F: FftField> WhirMerkleConfigWrapper<F> for KeccakConfigWrapper<F> {
         evals: &[F],
         whir_proof: &WhirProof<Self::MerkleConfig, F>,
     ) -> ProofResult<<Self::MerkleConfig as Config>::InnerDigest> {
-        verifier.simple_batch_verify(arthur, point, evals, whir_proof)
+        panic!("batched opening not supported!")
+        // verifier.simple_batch_verify(arthur, point, evals, whir_proof)
     }
 
     fn commit_statement_to_io_pattern(

--- a/src/poly_utils/evals.rs
+++ b/src/poly_utils/evals.rs
@@ -8,7 +8,7 @@ use super::{sequential_lag_poly::LagrangePolynomialIterator, MultilinearPoint};
 /// unknowns, stored via their evaluations at {0,1}^{num_variables}
 ///
 /// `evals` stores the evaluation in lexicographic order.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EvaluationsList<F> {
     evals: Vec<F>,
     num_variables: usize,

--- a/src/sumcheck/mod.rs
+++ b/src/sumcheck/mod.rs
@@ -1,7 +1,9 @@
 pub mod proof;
 pub mod prover_core;
 pub mod prover_not_skipping;
+pub mod prover_not_skipping_batched;
 pub mod prover_single;
+pub mod prover_batched;
 
 #[cfg(test)]
 mod tests {

--- a/src/sumcheck/prover_batched.rs
+++ b/src/sumcheck/prover_batched.rs
@@ -56,6 +56,20 @@ where
         prover
     }
 
+    pub fn get_folded_polys(&self) -> Vec<F> {
+        self.evaluations_of_p.iter().map(|e| {
+            assert_eq!(e.num_variables(), 0);
+            e.evals()[0]
+        }).collect()
+    }
+
+    pub fn get_folded_eqs(&self) -> Vec<F> {
+        self.evaluations_of_equality.iter().map(|e| {
+            assert_eq!(e.num_variables(), 0);
+            e.evals()[0]
+        }).collect()
+    }
+
     #[cfg(not(feature = "parallel"))]
     pub fn compute_sumcheck_polynomial(&self) -> SumcheckPolynomial<F> {
         panic!("Non-parallel version not supported!");

--- a/src/sumcheck/prover_batched.rs
+++ b/src/sumcheck/prover_batched.rs
@@ -44,7 +44,11 @@ where
             sum: F::ZERO,
         };
 
-        prover.add_new_equality(points, poly_comb_coeff, evals);
+        // Eval points
+        for (i, point) in points.iter().enumerate() {
+            SumcheckSingle::eval_eq(&point.0, prover.evaluations_of_equality[i].evals_mut(), F::from(1));
+            prover.sum += poly_comb_coeff[i] * evals[i];
+        }
         prover
     }
 
@@ -131,21 +135,6 @@ where
         let eval_2 = eval_1 + c1 + c2 + c2.double();
 
         SumcheckPolynomial::new(vec![eval_0, eval_1, eval_2], 1)
-    }
-
-    pub fn add_new_equality(
-        &mut self,
-        points: &[MultilinearPoint<F>],
-        poly_comb_coeff: &[F],
-        evals: &[F],
-    ) {
-        assert_eq!(points.len(), evals.len());
-        
-        // Eval points
-        for (i, point) in points.iter().enumerate() {
-            SumcheckSingle::eval_eq(&point.0, self.evaluations_of_equality[i].evals_mut(), F::from(1));
-            self.sum += poly_comb_coeff[i] * evals[i];
-        }
     }
 
     // When the folding randomness arrives, compress the table accordingly (adding the new points)

--- a/src/sumcheck/prover_batched.rs
+++ b/src/sumcheck/prover_batched.rs
@@ -1,0 +1,325 @@
+use super::proof::SumcheckPolynomial;
+use crate::{poly_utils::{coeffs::CoefficientList, evals::EvaluationsList, MultilinearPoint}, sumcheck::prover_single::SumcheckSingle};
+use ark_ff::Field;
+#[cfg(feature = "parallel")]
+use rayon::{join, prelude::*};
+
+pub struct SumcheckBatched<F> {
+    // The evaluation on each p and eq
+    evaluations_of_p: Vec<EvaluationsList<F>>,
+    evaluations_of_equality: Vec<EvaluationsList<F>>,
+    comb_coeff: Vec<F>,
+    num_polys: usize,
+    num_variables: usize,
+    sum: F,
+}
+
+impl<F> SumcheckBatched<F>
+where
+    F: Field,
+{
+    // Input includes the following:
+    // coeffs: coefficient of a list of polynomials p
+    // seq_points: points that will be evaluated on every polynomial (OOD points)
+    // par_points: one point per poly (eval points)
+    // and initialises the table of the initial polynomial
+    // v(X_1, ..., X_n) = comb_coeff0 * p0(X_1, ... X_n) * (epsilon_1 eq_z_1(X) + epsilon_2 eq_z_2(X) ...) + comb_coeff1 * p1(..) * eq1(..) + ...
+    pub fn new(
+        coeffs: Vec<CoefficientList<F>>,
+        seq_points: &[MultilinearPoint<F>],
+        par_points: &[MultilinearPoint<F>],
+        point_comb_coeff: &[F], // random coefficients for combining each point
+        poly_comb_coeff: &[F], // random coefficients for combining each poly
+        seq_evals_per_point: &[Vec<F>],
+        par_evals: &[F],
+    ) -> Self {
+        let num_polys = coeffs.len();
+        assert_eq!(point_comb_coeff.len(), seq_points.len() + 1); // 1 for par_points
+        assert_eq!(poly_comb_coeff.len(), num_polys);
+        assert_eq!(par_points.len(), num_polys);
+        for seq_evals in seq_evals_per_point {
+            assert_eq!(seq_evals.len(), num_polys);
+        }
+        assert_eq!(par_evals.len(), num_polys);
+        let num_variables = coeffs[0].num_variables();
+
+        let mut prover = SumcheckBatched {
+            evaluations_of_p: coeffs.into_iter().map(|c| c.into()).collect(),
+            evaluations_of_equality: vec![EvaluationsList::new(vec![F::ZERO; 1 << num_variables]); num_polys],
+            comb_coeff: poly_comb_coeff.to_vec(),
+            num_polys,
+            num_variables,
+            sum: F::ZERO,
+        };
+
+        prover.add_new_equality(seq_points, par_points, point_comb_coeff, poly_comb_coeff, seq_evals_per_point, par_evals);
+        prover
+    }
+
+    #[cfg(not(feature = "parallel"))]
+    pub fn compute_sumcheck_polynomial(&self) -> SumcheckPolynomial<F> {
+        panic!("Non-parallel version not supported!");
+        assert!(self.num_variables >= 1);
+
+        // Compute coefficients of the quadratic result polynomial
+        let eval_p_iter = self.evaluation_of_p.evals().chunks_exact(2);
+        let eval_eq_iter = self.evaluation_of_equality.evals().chunks_exact(2);
+        let (c0, c2) = eval_p_iter
+            .zip(eval_eq_iter)
+            .map(|(p_at, eq_at)| {
+                // Convert evaluations to coefficients for the linear fns p and eq.
+                let (p_0, p_1) = (p_at[0], p_at[1] - p_at[0]);
+                let (eq_0, eq_1) = (eq_at[0], eq_at[1] - eq_at[0]);
+
+                // Now we need to add the contribution of p(x) * eq(x)
+                (p_0 * eq_0, p_1 * eq_1)
+            })
+            .reduce(|(a0, a2), (b0, b2)| (a0 + b0, a2 + b2))
+            .unwrap_or((F::ZERO, F::ZERO));
+
+        // Use the fact that self.sum = p(0) + p(1) = 2 * c0 + c1 + c2
+        let c1 = self.sum - c0.double() - c2;
+
+        // Evaluate the quadratic polynomial at 0, 1, 2
+        let eval_0 = c0;
+        let eval_1 = c0 + c1 + c2;
+        let eval_2 = eval_1 + c1 + c2 + c2.double();
+
+        SumcheckPolynomial::new(vec![eval_0, eval_1, eval_2], 1)
+    }
+
+    #[cfg(feature = "parallel")]
+    pub fn compute_sumcheck_polynomial(&self) -> SumcheckPolynomial<F> {
+        assert!(self.num_variables >= 1);
+        
+        // Compute coefficients of the quadratic result polynomial
+        let (_, c0, c2) = self.comb_coeff.par_iter().zip(&self.evaluations_of_p).zip(&self.evaluations_of_equality).map(|((rand, eval_p), eval_eq)| {
+            let eval_p_iter = eval_p.evals().par_chunks_exact(2);
+            let eval_eq_iter = eval_eq.evals().par_chunks_exact(2);
+            let (c0, c2) = eval_p_iter
+                .zip(eval_eq_iter)
+                .map(|(p_at, eq_at)| {
+                    // Convert evaluations to coefficients for the linear fns p and eq.
+                    let (p_0, p_1) = (p_at[0], p_at[1] - p_at[0]);
+                    let (eq_0, eq_1) = (eq_at[0], eq_at[1] - eq_at[0]);
+
+                    // Now we need to add the contribution of p(x) * eq(x)
+                    (p_0 * eq_0, p_1 * eq_1)
+                })
+                .reduce(
+                    || (F::ZERO, F::ZERO),
+                    |(a0, a2), (b0, b2)| (a0 + b0, a2 + b2),
+                );
+            (rand.clone(), c0, c2)
+        }).reduce(
+            || (F::ONE, F::ZERO, F::ZERO),
+            |(r0, a0, a2), (r1, b0, b2)| (F::ONE, r0 * a0 + r1 * b0, r0 * a2 + r1 * b2),
+        );
+
+        // Use the fact that self.sum = p(0) + p(1) = 2 * coeff_0 + coeff_1 + coeff_2
+        let c1 = self.sum - c0.double() - c2;
+
+        // Evaluate the quadratic polynomial at 0, 1, 2
+        let eval_0 = c0;
+        let eval_1 = c0 + c1 + c2;
+        let eval_2 = eval_1 + c1 + c2 + c2.double();
+
+        SumcheckPolynomial::new(vec![eval_0, eval_1, eval_2], 1)
+    }
+
+    pub fn add_new_equality(
+        &mut self,
+        seq_points: &[MultilinearPoint<F>],
+        par_points: &[MultilinearPoint<F>],
+        point_comb_coeff: &[F],
+        poly_comb_coeff: &[F],
+        seq_evals_per_point: &[Vec<F>],
+        par_evals: &[F],
+    ) {
+        assert_eq!(seq_points.len(), seq_evals_per_point.len());
+        assert_eq!(par_points.len(), par_evals.len());
+        // OOD points
+        // TODO: optimize the processes below: EQs of every SEQ_POINTS should only be computed once!
+        for (i, (point, seq_point_coeff)) in seq_points.iter().zip(point_comb_coeff).enumerate() {
+            for evals in &mut self.evaluations_of_equality {
+                SumcheckSingle::eval_eq(&point.0, evals.evals_mut(), *seq_point_coeff);
+            }
+            for j in 0..self.num_polys {
+                self.sum += poly_comb_coeff[j] * seq_evals_per_point[i][j] * seq_point_coeff;
+            }
+        }
+        
+        // Eval points
+        let par_point_coeff = point_comb_coeff[seq_points.len()];
+        for (i, point) in par_points.iter().enumerate() {
+            SumcheckSingle::eval_eq(&point.0, self.evaluations_of_equality[i].evals_mut(), par_point_coeff);
+            self.sum += poly_comb_coeff[i] * par_evals[i] * par_point_coeff;
+        }
+    }
+
+    // When the folding randomness arrives, compress the table accordingly (adding the new points)
+    #[cfg(not(feature = "parallel"))]
+    pub fn compress(
+        &mut self,
+        combination_randomness: F, // Scale the initial point
+        folding_randomness: &MultilinearPoint<F>,
+        sumcheck_poly: &SumcheckPolynomial<F>,
+    ) {
+        panic!("Non-parallel version not supported!");
+        assert_eq!(folding_randomness.n_variables(), 1);
+        assert!(self.num_variables >= 1);
+
+        let randomness = folding_randomness.0[0];
+        let evaluations_of_p = self
+            .evaluation_of_p
+            .evals()
+            .chunks_exact(2)
+            .map(|at| (at[1] - at[0]) * randomness + at[0])
+            .collect();
+        let evaluations_of_eq = self
+            .evaluation_of_equality
+            .evals()
+            .chunks_exact(2)
+            .map(|at| (at[1] - at[0]) * randomness + at[0])
+            .collect();
+
+        // Update
+        self.num_variables -= 1;
+        self.evaluation_of_p = EvaluationsList::new(evaluations_of_p);
+        self.evaluation_of_equality = EvaluationsList::new(evaluations_of_eq);
+        self.sum = combination_randomness * sumcheck_poly.evaluate_at_point(folding_randomness);
+    }
+
+    #[cfg(feature = "parallel")]
+    pub fn compress(
+        &mut self,
+        combination_randomness: F, // Scale the initial point
+        folding_randomness: &MultilinearPoint<F>,
+        sumcheck_poly: &SumcheckPolynomial<F>,
+    ) {
+        assert_eq!(folding_randomness.n_variables(), 1);
+        assert!(self.num_variables >= 1);
+
+        let randomness = folding_randomness.0[0];
+        let evaluations: Vec<_> = self.evaluations_of_p.par_iter().zip(&self.evaluations_of_equality).map(|(eval_p, eval_eq)| {
+            let (evaluation_of_p, evaluation_of_eq) = join(
+                || {
+                    eval_p
+                        .evals()
+                        .par_chunks_exact(2)
+                        .map(|at| (at[1] - at[0]) * randomness + at[0])
+                        .collect()
+                },
+                || {
+                    eval_eq
+                        .evals()
+                        .par_chunks_exact(2)
+                        .map(|at| (at[1] - at[0]) * randomness + at[0])
+                        .collect()
+                },
+            );
+            (EvaluationsList::new(evaluation_of_p), EvaluationsList::new(evaluation_of_eq))
+        }).collect();
+        let (evaluations_of_p, evaluations_of_eq)= evaluations.into_iter().unzip();
+
+        // Update
+        self.num_variables -= 1;
+        self.evaluations_of_p = evaluations_of_p;
+        self.evaluations_of_equality = evaluations_of_eq;
+        self.sum = combination_randomness * sumcheck_poly.evaluate_at_point(folding_randomness);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        crypto::fields::Field64,
+        poly_utils::{coeffs::CoefficientList, MultilinearPoint},
+    };
+
+    use super::SumcheckBatched;
+
+    type F = Field64;
+
+    #[test]
+    fn test_sumcheck_folding_factor_1() {
+        let num_rounds = 2;
+        let ood_points = vec![
+            MultilinearPoint(vec![F::from(4574), F::from(6839)]),
+            MultilinearPoint(vec![F::from(9283), F::from(4792)]),
+        ];
+        let eval_points = vec![
+            MultilinearPoint(vec![F::from(10), F::from(11)]),
+            MultilinearPoint(vec![F::from(7), F::from(8)]),
+        ];
+        let polynomials = vec![
+            CoefficientList::new(vec![F::from(1), F::from(5), F::from(10), F::from(14)]),
+            CoefficientList::new(vec![F::from(2), F::from(6), F::from(11), F::from(13)]),
+        ];
+        let point_comb_coeffs = vec![F::from(4), F::from(5), F::from(6)];
+        let poly_comb_coeffs = vec![F::from(2), F::from(3)];
+
+        let seq_evals: Vec<Vec<F>> = ood_points.iter().map(|point|
+            polynomials.iter().map(|poly|
+                poly.evaluate(point)
+            ).collect()
+        ).collect();
+        let par_evals: Vec<F> = polynomials.iter().zip(&eval_points).map(|(poly, point)| 
+            poly.evaluate(point)
+        ).collect();
+        let mut claimed_value: F = seq_evals
+            .iter()
+            .zip(&point_comb_coeffs)
+            .fold(F::from(0), |sum, (evals, point_rand)|
+                evals
+                .iter()
+                .zip(&poly_comb_coeffs)
+                .fold(F::from(0), |sum, (eval, poly_rand)| 
+                    eval * poly_rand + sum
+                ) * point_rand + sum
+            ) 
+        + par_evals
+            .iter()
+            .zip(&poly_comb_coeffs)
+            .fold(F::from(0), |sum, (eval, poly_rand)| 
+                eval * poly_rand + sum
+            ) * point_comb_coeffs[ood_points.len()];
+        
+        let mut prover = SumcheckBatched::new(
+            polynomials.clone(), 
+            &ood_points,
+            &eval_points, 
+            &point_comb_coeffs,
+            &poly_comb_coeffs,
+            &seq_evals,
+            &par_evals,
+        );
+        let mut comb_randomness_list = Vec::new();
+        let mut fold_randomness_list = Vec::new();
+
+        for _ in 0..num_rounds {
+            let poly = prover.compute_sumcheck_polynomial();
+
+            // First, check that is sums to the right value over the hypercube
+            assert_eq!(poly.sum_over_hypercube(), claimed_value);
+
+            let next_comb_randomness = F::from(100101);
+            let next_fold_randomness = MultilinearPoint(vec![F::from(4999)]);
+
+            prover.compress(next_comb_randomness, &next_fold_randomness, &poly);
+            claimed_value = next_comb_randomness * poly.evaluate_at_point(&next_fold_randomness);
+
+            comb_randomness_list.push(next_comb_randomness);
+            fold_randomness_list.extend(next_fold_randomness.0);
+        }
+        println!("CLAIM:");
+        for poly in prover.evaluations_of_p {
+            println!("POLY: {:?}", poly);
+        }
+        println!("EXPECTED:");
+        let fold_randomness_list = MultilinearPoint(fold_randomness_list);
+        for poly in polynomials {
+            println!("EVAL: {:?}", poly.evaluate(&fold_randomness_list));
+        }
+    }
+}

--- a/src/sumcheck/prover_not_skipping_batched.rs
+++ b/src/sumcheck/prover_not_skipping_batched.rs
@@ -39,6 +39,14 @@ where
         }
     }
 
+    pub fn get_folded_polys(&self) -> Vec<F> {
+        self.sumcheck_prover.get_folded_polys()
+    }
+
+    pub fn _get_folded_eqs(&self) -> Vec<F> {
+        self.sumcheck_prover.get_folded_eqs()
+    }
+
     pub fn compute_sumcheck_polynomials<S, Merlin>(
         &mut self,
         merlin: &mut Merlin,
@@ -68,19 +76,6 @@ where
 
         res.reverse();
         Ok(MultilinearPoint(res))
-    }
-
-    pub fn add_new_equality(
-        &mut self,
-        seq_points: &[MultilinearPoint<F>],
-        par_points: &[MultilinearPoint<F>],
-        point_comb_coeff: &[F],
-        poly_comb_coeff: &[F],
-        seq_evals_per_point: &[Vec<F>],
-        par_evals: &[F],
-    ) {
-        self.sumcheck_prover
-            .add_new_equality(seq_points, par_points, point_comb_coeff, poly_comb_coeff, seq_evals_per_point, par_evals)
     }
 }
 
@@ -199,126 +194,4 @@ mod tests {
 
         Ok(())
     }
-
-    /*
-    #[test]
-    fn test_e2e() -> ProofResult<()> {
-        let num_variables = 4;
-        let folding_factor = 2;
-        let polynomial = CoefficientList::new((0..1 << num_variables).map(F::from).collect());
-
-        // Initial stuff
-        let ood_point = MultilinearPoint::expand_from_univariate(F::from(42), num_variables);
-        let statement_point = MultilinearPoint::expand_from_univariate(F::from(97), num_variables);
-
-        // All the randomness
-        let [epsilon_1, epsilon_2] = [F::from(15), F::from(32)];
-        let fold_point = MultilinearPoint(vec![F::from(31), F::from(15)]);
-        let combination_randomness = vec![F::from(1000)];
-
-        fn add_sumcheck_io_pattern<F>() -> IOPattern
-        where
-            F: Field,
-            IOPattern: FieldIOPattern<F>,
-        {
-            IOPattern::new("test")
-                .add_scalars(3, "sumcheck_poly")
-                .challenge_scalars(1, "folding_randomness")
-                .add_scalars(3, "sumcheck_poly")
-                .challenge_scalars(1, "folding_randomness")
-                .add_scalars(3, "sumcheck_poly")
-                .challenge_scalars(1, "folding_randomness")
-                .add_scalars(3, "sumcheck_poly")
-                .challenge_scalars(1, "folding_randomness")
-        }
-
-        let iopattern = add_sumcheck_io_pattern::<F>();
-
-        // Prover part
-        let mut merlin = iopattern.to_merlin();
-        let mut prover = SumcheckProverNotSkipping::new(
-            polynomial.clone(),
-            &[ood_point.clone(), statement_point.clone()],
-            &[epsilon_1, epsilon_2],
-            &[
-                polynomial.evaluate_at_extension(&ood_point),
-                polynomial.evaluate_at_extension(&statement_point),
-            ],
-        );
-
-        let folding_randomness_1 =
-            prover.compute_sumcheck_polynomials::<Blake3PoW, Merlin>(&mut merlin, folding_factor, 0.)?;
-
-        let folded_poly_1 = polynomial.fold(&folding_randomness_1);
-        let fold_eval = folded_poly_1.evaluate_at_extension(&fold_point);
-        prover.add_new_equality(&[fold_point.clone()], &combination_randomness, &[fold_eval]);
-
-        let folding_randomness_2 =
-            prover.compute_sumcheck_polynomials::<Blake3PoW, Merlin>(&mut merlin, folding_factor, 0.)?;
-
-        // Compute the answers
-        let folded_poly_1 = polynomial.fold(&folding_randomness_1);
-        let folded_poly_2 = folded_poly_1.fold(&folding_randomness_2);
-
-        let ood_answer = polynomial.evaluate(&ood_point);
-        let statement_answer = polynomial.evaluate(&statement_point);
-        let fold_answer = folded_poly_1.evaluate(&fold_point);
-
-        // Verifier part
-        let mut arthur = iopattern.to_arthur(merlin.transcript());
-        let sumcheck_poly_11: [F; 3] = arthur.next_scalars()?;
-        let sumcheck_poly_11 = SumcheckPolynomial::new(sumcheck_poly_11.to_vec(), 1);
-        let [folding_randomness_11]: [F; 1] = arthur.challenge_scalars()?;
-        let sumcheck_poly_12: [F; 3] = arthur.next_scalars()?;
-        let sumcheck_poly_12 = SumcheckPolynomial::new(sumcheck_poly_12.to_vec(), 1);
-        let [folding_randomness_12]: [F; 1] = arthur.challenge_scalars()?;
-        let sumcheck_poly_21: [F; 3] = arthur.next_scalars()?;
-        let sumcheck_poly_21 = SumcheckPolynomial::new(sumcheck_poly_21.to_vec(), 1);
-        let [folding_randomness_21]: [F; 1] = arthur.challenge_scalars()?;
-        let sumcheck_poly_22: [F; 3] = arthur.next_scalars()?;
-        let sumcheck_poly_22 = SumcheckPolynomial::new(sumcheck_poly_22.to_vec(), 1);
-        let [folding_randomness_22]: [F; 1] = arthur.challenge_scalars()?;
-
-        assert_eq!(
-            sumcheck_poly_11.sum_over_hypercube(),
-            epsilon_1 * ood_answer + epsilon_2 * statement_answer
-        );
-
-        assert_eq!(
-            sumcheck_poly_12.sum_over_hypercube(),
-            sumcheck_poly_11.evaluate_at_point(&folding_randomness_11.into())
-        );
-
-        assert_eq!(
-            sumcheck_poly_21.sum_over_hypercube(),
-            sumcheck_poly_12.evaluate_at_point(&folding_randomness_12.into())
-                + combination_randomness[0] * fold_answer
-        );
-
-        assert_eq!(
-            sumcheck_poly_22.sum_over_hypercube(),
-            sumcheck_poly_21.evaluate_at_point(&folding_randomness_21.into())
-        );
-
-        let full_folding = MultilinearPoint(vec![
-            folding_randomness_22,
-            folding_randomness_21,
-            folding_randomness_12,
-            folding_randomness_11,
-        ]);
-
-        let partial_folding = MultilinearPoint(vec![folding_randomness_22, folding_randomness_21]);
-
-        let eval_coeff = folded_poly_2.coeffs()[0];
-        assert_eq!(
-            sumcheck_poly_22.evaluate_at_point(&folding_randomness_22.into()),
-            eval_coeff
-                * ((epsilon_1 * eq_poly_outside(&full_folding, &ood_point)
-                    + epsilon_2 * eq_poly_outside(&full_folding, &statement_point))
-                    + combination_randomness[0] * eq_poly_outside(&partial_folding, &fold_point))
-        );
-
-        Ok(())
-    }
-    */
 }

--- a/src/sumcheck/prover_not_skipping_batched.rs
+++ b/src/sumcheck/prover_not_skipping_batched.rs
@@ -1,0 +1,324 @@
+use ark_ff::Field;
+use nimue::{plugins::ark::{FieldChallenges, FieldWriter}, ProofResult};
+use nimue_pow::{PoWChallenge, PowStrategy};
+
+use crate::poly_utils::{coeffs::CoefficientList, MultilinearPoint};
+
+use super::prover_batched::SumcheckBatched;
+
+pub struct SumcheckProverNotSkippingBatched<F> {
+    sumcheck_prover: SumcheckBatched<F>,
+}
+
+impl<F> SumcheckProverNotSkippingBatched<F>
+where
+    F: Field,
+{
+    // Get the coefficient of polynomial p and a list of points
+    // and initialises the table of the initial polynomial
+    // v(X_1, ..., X_n) = p(X_1, ... X_n) * (epsilon_1 eq_z_1(X) + epsilon_2 eq_z_2(X) ...)
+    pub fn new(
+        coeffs: Vec<CoefficientList<F>>,
+        seq_points: &[MultilinearPoint<F>],
+        par_points: &[MultilinearPoint<F>],
+        point_comb_coeff: &[F], // random coefficients for combining each point
+        poly_comb_coeff: &[F], // random coefficients for combining each poly
+        seq_evals_per_point: &[Vec<F>],
+        par_evals: &[F],
+    ) -> Self {
+        Self {
+            sumcheck_prover: SumcheckBatched::new(
+                coeffs,
+                seq_points,
+                par_points,
+                point_comb_coeff,
+                poly_comb_coeff,
+                seq_evals_per_point,
+                par_evals,
+            ),
+        }
+    }
+
+    pub fn compute_sumcheck_polynomials<S, Merlin>(
+        &mut self,
+        merlin: &mut Merlin,
+        folding_factor: usize,
+        pow_bits: f64,
+    ) -> ProofResult<MultilinearPoint<F>>
+    where
+        S: PowStrategy,
+        Merlin: FieldChallenges<F> + FieldWriter<F> + PoWChallenge,
+    {
+        let mut res = Vec::with_capacity(folding_factor);
+
+        for _ in 0..folding_factor {
+            let sumcheck_poly = self.sumcheck_prover.compute_sumcheck_polynomial();
+            merlin.add_scalars(sumcheck_poly.evaluations())?;
+            let [folding_randomness]: [F; 1] = merlin.challenge_scalars()?;
+            res.push(folding_randomness);
+
+            // Do PoW if needed
+            if pow_bits > 0. {
+                merlin.challenge_pow::<S>(pow_bits)?;
+            }
+
+            self.sumcheck_prover
+                .compress(F::ONE, &folding_randomness.into(), &sumcheck_poly);
+        }
+
+        res.reverse();
+        Ok(MultilinearPoint(res))
+    }
+
+    pub fn add_new_equality(
+        &mut self,
+        seq_points: &[MultilinearPoint<F>],
+        par_points: &[MultilinearPoint<F>],
+        point_comb_coeff: &[F],
+        poly_comb_coeff: &[F],
+        seq_evals_per_point: &[Vec<F>],
+        par_evals: &[F],
+    ) {
+        self.sumcheck_prover
+            .add_new_equality(seq_points, par_points, point_comb_coeff, poly_comb_coeff, seq_evals_per_point, par_evals)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_ff::Field;
+    use nimue::{plugins::ark::{FieldChallenges, FieldIOPattern, FieldReader}, IOPattern, Merlin, ProofResult};
+    use nimue_pow::blake3::Blake3PoW;
+
+    use crate::{
+        crypto::fields::Field64,
+        poly_utils::{coeffs::CoefficientList, eq_poly_outside, MultilinearPoint},
+        sumcheck::{proof::SumcheckPolynomial, prover_not_skipping_batched::SumcheckProverNotSkippingBatched},
+    };
+
+    type F = Field64;
+
+    #[test]
+    fn test_e2e_short() -> ProofResult<()> {
+        let num_variables = 2;
+        let folding_factor = 2;
+        let polynomials = vec![
+            CoefficientList::new((0..1 << num_variables).map(F::from).collect()),
+            CoefficientList::new((1..(1 << num_variables) + 1).map(F::from).collect()),
+        ];
+
+        // Initial stuff
+        let ood_point = MultilinearPoint::expand_from_univariate(F::from(42), num_variables);
+        let statement_points = vec![
+            MultilinearPoint::expand_from_univariate(F::from(97), num_variables),
+            MultilinearPoint::expand_from_univariate(F::from(75), num_variables),
+        ];
+
+        // Point randomness
+        let [epsilon_1, epsilon_2] = [F::from(15), F::from(32)];
+        // Poly randomness
+        let [alpha_1, alpha_2] = [F::from(15), F::from(32)];
+
+        fn add_sumcheck_io_pattern<F>() -> IOPattern
+        where
+            F: Field,
+            IOPattern: FieldIOPattern<F>,
+        {
+            IOPattern::new("test")
+                .add_scalars(3, "sumcheck_poly")
+                .challenge_scalars(1, "folding_randomness")
+                .add_scalars(3, "sumcheck_poly")
+                .challenge_scalars(1, "folding_randomness")
+        }
+
+        let iopattern = add_sumcheck_io_pattern::<F>();
+
+        // Prover part
+        let mut merlin = iopattern.to_merlin();
+        let mut prover = SumcheckProverNotSkippingBatched::new(
+            polynomials.clone(),
+            &[ood_point.clone()],
+            &statement_points,
+            &[epsilon_1, epsilon_2],
+            &[alpha_1, alpha_2],
+            &[vec![
+                polynomials[0].evaluate_at_extension(&ood_point),
+                polynomials[1].evaluate_at_extension(&ood_point),
+            ]],
+            &[
+                polynomials[0].evaluate_at_extension(&statement_points[0]),
+                polynomials[1].evaluate_at_extension(&statement_points[1]),
+            ]
+        );
+
+        let folding_randomness_1 =
+            prover.compute_sumcheck_polynomials::<Blake3PoW, Merlin>(&mut merlin, folding_factor, 0.)?;
+
+        // Compute the answers
+        let folded_polys_1: Vec<_> = polynomials.iter().map(|poly| poly.fold(&folding_randomness_1)).collect();
+
+        let ood_answers: Vec<F> = polynomials.iter().map(|poly| poly.evaluate(&ood_point)).collect();
+        let statement_answers: Vec<F> = polynomials.iter().zip(&statement_points).map(|(poly, point)|
+            poly.evaluate(point)
+        ).collect();
+
+        // Verifier part
+        let mut arthur = iopattern.to_arthur(merlin.transcript());
+        let sumcheck_poly_11: [F; 3] = arthur.next_scalars()?;
+        let sumcheck_poly_11 = SumcheckPolynomial::new(sumcheck_poly_11.to_vec(), 1);
+        let [folding_randomness_11]: [F; 1] = arthur.challenge_scalars()?;
+        let sumcheck_poly_12: [F; 3] = arthur.next_scalars()?;
+        let sumcheck_poly_12 = SumcheckPolynomial::new(sumcheck_poly_12.to_vec(), 1);
+        let [folding_randomness_12]: [F; 1] = arthur.challenge_scalars()?;
+
+        assert_eq!(
+            sumcheck_poly_11.sum_over_hypercube(),
+            epsilon_1 * alpha_1 * ood_answers[0] + 
+            epsilon_1 * alpha_2 * ood_answers[1] + 
+            epsilon_2 * alpha_1 * statement_answers[0] +
+            epsilon_2 * alpha_2 * statement_answers[1]
+        );
+
+        assert_eq!(
+            sumcheck_poly_12.sum_over_hypercube(),
+            sumcheck_poly_11.evaluate_at_point(&folding_randomness_11.into())
+        );
+
+        let full_folding = MultilinearPoint(vec![folding_randomness_12, folding_randomness_11]);
+
+        let eval_coeff = vec![folded_polys_1[0].coeffs()[0], folded_polys_1[1].coeffs()[0]];
+        assert_eq!(
+            sumcheck_poly_12.evaluate_at_point(&folding_randomness_12.into()),
+            eval_coeff[0] * alpha_1
+                * (epsilon_1 * eq_poly_outside(&full_folding, &ood_point)
+                    + epsilon_2 * eq_poly_outside(&full_folding, &statement_points[0]))
+            + eval_coeff[1] * alpha_2
+                * (epsilon_1 * eq_poly_outside(&full_folding, &ood_point)
+                    + epsilon_2 * eq_poly_outside(&full_folding, &statement_points[1]))
+        );
+
+        Ok(())
+    }
+
+    /*
+    #[test]
+    fn test_e2e() -> ProofResult<()> {
+        let num_variables = 4;
+        let folding_factor = 2;
+        let polynomial = CoefficientList::new((0..1 << num_variables).map(F::from).collect());
+
+        // Initial stuff
+        let ood_point = MultilinearPoint::expand_from_univariate(F::from(42), num_variables);
+        let statement_point = MultilinearPoint::expand_from_univariate(F::from(97), num_variables);
+
+        // All the randomness
+        let [epsilon_1, epsilon_2] = [F::from(15), F::from(32)];
+        let fold_point = MultilinearPoint(vec![F::from(31), F::from(15)]);
+        let combination_randomness = vec![F::from(1000)];
+
+        fn add_sumcheck_io_pattern<F>() -> IOPattern
+        where
+            F: Field,
+            IOPattern: FieldIOPattern<F>,
+        {
+            IOPattern::new("test")
+                .add_scalars(3, "sumcheck_poly")
+                .challenge_scalars(1, "folding_randomness")
+                .add_scalars(3, "sumcheck_poly")
+                .challenge_scalars(1, "folding_randomness")
+                .add_scalars(3, "sumcheck_poly")
+                .challenge_scalars(1, "folding_randomness")
+                .add_scalars(3, "sumcheck_poly")
+                .challenge_scalars(1, "folding_randomness")
+        }
+
+        let iopattern = add_sumcheck_io_pattern::<F>();
+
+        // Prover part
+        let mut merlin = iopattern.to_merlin();
+        let mut prover = SumcheckProverNotSkipping::new(
+            polynomial.clone(),
+            &[ood_point.clone(), statement_point.clone()],
+            &[epsilon_1, epsilon_2],
+            &[
+                polynomial.evaluate_at_extension(&ood_point),
+                polynomial.evaluate_at_extension(&statement_point),
+            ],
+        );
+
+        let folding_randomness_1 =
+            prover.compute_sumcheck_polynomials::<Blake3PoW, Merlin>(&mut merlin, folding_factor, 0.)?;
+
+        let folded_poly_1 = polynomial.fold(&folding_randomness_1);
+        let fold_eval = folded_poly_1.evaluate_at_extension(&fold_point);
+        prover.add_new_equality(&[fold_point.clone()], &combination_randomness, &[fold_eval]);
+
+        let folding_randomness_2 =
+            prover.compute_sumcheck_polynomials::<Blake3PoW, Merlin>(&mut merlin, folding_factor, 0.)?;
+
+        // Compute the answers
+        let folded_poly_1 = polynomial.fold(&folding_randomness_1);
+        let folded_poly_2 = folded_poly_1.fold(&folding_randomness_2);
+
+        let ood_answer = polynomial.evaluate(&ood_point);
+        let statement_answer = polynomial.evaluate(&statement_point);
+        let fold_answer = folded_poly_1.evaluate(&fold_point);
+
+        // Verifier part
+        let mut arthur = iopattern.to_arthur(merlin.transcript());
+        let sumcheck_poly_11: [F; 3] = arthur.next_scalars()?;
+        let sumcheck_poly_11 = SumcheckPolynomial::new(sumcheck_poly_11.to_vec(), 1);
+        let [folding_randomness_11]: [F; 1] = arthur.challenge_scalars()?;
+        let sumcheck_poly_12: [F; 3] = arthur.next_scalars()?;
+        let sumcheck_poly_12 = SumcheckPolynomial::new(sumcheck_poly_12.to_vec(), 1);
+        let [folding_randomness_12]: [F; 1] = arthur.challenge_scalars()?;
+        let sumcheck_poly_21: [F; 3] = arthur.next_scalars()?;
+        let sumcheck_poly_21 = SumcheckPolynomial::new(sumcheck_poly_21.to_vec(), 1);
+        let [folding_randomness_21]: [F; 1] = arthur.challenge_scalars()?;
+        let sumcheck_poly_22: [F; 3] = arthur.next_scalars()?;
+        let sumcheck_poly_22 = SumcheckPolynomial::new(sumcheck_poly_22.to_vec(), 1);
+        let [folding_randomness_22]: [F; 1] = arthur.challenge_scalars()?;
+
+        assert_eq!(
+            sumcheck_poly_11.sum_over_hypercube(),
+            epsilon_1 * ood_answer + epsilon_2 * statement_answer
+        );
+
+        assert_eq!(
+            sumcheck_poly_12.sum_over_hypercube(),
+            sumcheck_poly_11.evaluate_at_point(&folding_randomness_11.into())
+        );
+
+        assert_eq!(
+            sumcheck_poly_21.sum_over_hypercube(),
+            sumcheck_poly_12.evaluate_at_point(&folding_randomness_12.into())
+                + combination_randomness[0] * fold_answer
+        );
+
+        assert_eq!(
+            sumcheck_poly_22.sum_over_hypercube(),
+            sumcheck_poly_21.evaluate_at_point(&folding_randomness_21.into())
+        );
+
+        let full_folding = MultilinearPoint(vec![
+            folding_randomness_22,
+            folding_randomness_21,
+            folding_randomness_12,
+            folding_randomness_11,
+        ]);
+
+        let partial_folding = MultilinearPoint(vec![folding_randomness_22, folding_randomness_21]);
+
+        let eval_coeff = folded_poly_2.coeffs()[0];
+        assert_eq!(
+            sumcheck_poly_22.evaluate_at_point(&folding_randomness_22.into()),
+            eval_coeff
+                * ((epsilon_1 * eq_poly_outside(&full_folding, &ood_point)
+                    + epsilon_2 * eq_poly_outside(&full_folding, &statement_point))
+                    + combination_randomness[0] * eq_poly_outside(&partial_folding, &fold_point))
+        );
+
+        Ok(())
+    }
+    */
+}

--- a/src/sumcheck/prover_single.rs
+++ b/src/sumcheck/prover_single.rs
@@ -72,7 +72,7 @@ where
     }
 
     #[cfg(feature = "parallel")]
-    pub fn compute_sumcheck_polynomial(&self) -> SumcheckPolynomial<F> {
+    pub(crate) fn compute_sumcheck_polynomial(&self) -> SumcheckPolynomial<F> {
         assert!(self.num_variables >= 1);
 
         // Compute coefficients of the quadratic result polynomial
@@ -107,7 +107,7 @@ where
     // Evaluate the eq function on for a given point on the hypercube, and add
     // the result multiplied by the scalar to the output.
     #[cfg(not(feature = "parallel"))]
-    fn eval_eq(eval: &[F], out: &mut [F], scalar: F) {
+    pub(crate) fn eval_eq(eval: &[F], out: &mut [F], scalar: F) {
         debug_assert_eq!(out.len(), 1 << eval.len());
         if let Some((&x, tail)) = eval.split_first() {
             let (low, high) = out.split_at_mut(out.len() / 2);
@@ -123,7 +123,7 @@ where
     // Evaluate the eq function on a given point on the hypercube, and add
     // the result multiplied by the scalar to the output.
     #[cfg(feature = "parallel")]
-    fn eval_eq(eval: &[F], out: &mut [F], scalar: F) {
+    pub fn eval_eq(eval: &[F], out: &mut [F], scalar: F) {
         const PARALLEL_THRESHOLD: usize = 10;
         debug_assert_eq!(out.len(), 1 << eval.len());
         if let Some((&x, tail)) = eval.split_first() {

--- a/src/sumcheck/prover_single.rs
+++ b/src/sumcheck/prover_single.rs
@@ -41,7 +41,7 @@ where
     }
 
     #[cfg(not(feature = "parallel"))]
-    pub fn compute_sumcheck_polynomial(&self) -> SumcheckPolynomial<F> {
+    pub(crate) fn compute_sumcheck_polynomial(&self) -> SumcheckPolynomial<F> {
         assert!(self.num_variables >= 1);
 
         // Compute coefficients of the quadratic result polynomial
@@ -123,7 +123,7 @@ where
     // Evaluate the eq function on a given point on the hypercube, and add
     // the result multiplied by the scalar to the output.
     #[cfg(feature = "parallel")]
-    pub fn eval_eq(eval: &[F], out: &mut [F], scalar: F) {
+    pub(crate) fn eval_eq(eval: &[F], out: &mut [F], scalar: F) {
         const PARALLEL_THRESHOLD: usize = 10;
         debug_assert_eq!(out.len(), 1 << eval.len());
         if let Some((&x, tail)) = eval.split_first() {

--- a/src/whir/batch/iopattern.rs
+++ b/src/whir/batch/iopattern.rs
@@ -16,6 +16,11 @@ pub trait WhirBatchIOPattern<F: FftField, MerkleConfig: Config> {
         params: &WhirConfig<F, MerkleConfig, PowStrategy>,
         batch_size: usize,
     ) -> Self;
+    fn add_whir_unify_proof<PowStrategy>(
+        self,
+        params: &WhirConfig<F, MerkleConfig, PowStrategy>,
+        batch_size: usize,
+    ) -> Self;
     fn add_whir_batch_proof<PowStrategy>(
         self,
         params: &WhirConfig<F, MerkleConfig, PowStrategy>,
@@ -48,6 +53,20 @@ where
                 .add_scalars(params.committment_ood_samples * batch_size, "ood_ans");
         }
         this
+    }
+
+    fn add_whir_unify_proof<PowStrategy>(
+        mut self,
+        params: &WhirConfig<F, MerkleConfig, PowStrategy>,
+        batch_size: usize,
+    ) -> Self {
+        if batch_size > 1 {
+            self = self.challenge_scalars(1, "batch_poly_combination_randomness");
+        }
+        self = self
+            // .challenge_scalars(1, "initial_combination_randomness")
+            .add_sumcheck(params.mv_parameters.num_variables, 0.);
+        self.add_scalars(batch_size, "unified_folded_evals")
     }
 
     fn add_whir_batch_proof<PowStrategy>(

--- a/src/whir/batch/prover.rs
+++ b/src/whir/batch/prover.rs
@@ -498,20 +498,11 @@ where
         let initial_eval_claims = point_per_poly.clone();
         end_timer!(initial_claims_timer);
 
-        // let comb_timer = start_timer!(|| "combination randomness");
-        // let num_points = 1; // do not process ood points
-        // let [point_comb_randomness_gen] = merlin.challenge_scalars()?;
-        // let point_comb_randomness = expand_randomness(point_comb_randomness_gen, num_points);
-        // end_timer!(comb_timer);
-
         let sumcheck_timer = start_timer!(|| "unifying sumcheck");
         let mut sumcheck_prover = SumcheckProverNotSkippingBatched::new(
             witness.polys.clone(),
-            &Vec::new(),
             &initial_eval_claims,
-            &vec![F::from(1)],
             &poly_comb_randomness,
-            &Vec::new(),
             &eval_per_poly,
         );
 

--- a/src/whir/batch/prover.rs
+++ b/src/whir/batch/prover.rs
@@ -68,8 +68,8 @@ where
     pub fn simple_batch_prove<Merlin>(
         &self,
         merlin: &mut Merlin,
-        points: &Vec<MultilinearPoint<F>>,
-        evals_per_point: &Vec<Vec<F>>, // outer loop on each point, inner loop on each poly
+        points: &[MultilinearPoint<F>],
+        evals_per_point: &[Vec<F>], // outer loop on each point, inner loop on each poly
         witness: &Witnesses<F, MerkleConfig>,
     ) -> ProofResult<WhirProof<MerkleConfig, F>>
     where
@@ -120,7 +120,7 @@ where
                     self.0.mv_parameters.num_variables,
                 )
             })
-            .chain(points.clone()).collect();
+            .chain(points.to_vec()).collect();
         end_timer!(initial_claims_timer);
 
         let ood_answers_timer = start_timer!(|| "ood answers");

--- a/src/whir/batch/prover.rs
+++ b/src/whir/batch/prover.rs
@@ -515,8 +515,8 @@ where
             )?;
         let folded_evals = sumcheck_prover.get_folded_polys();
         merlin.add_scalars(&folded_evals)?;
-        // Problem now reduced to the polys(folded_point) =?= folded_evals
         end_timer!(sumcheck_timer);
+        // Problem now reduced to the polys(folded_point) =?= folded_evals
 
         let timer = start_timer!(|| "simple_batch");
         // perform simple_batch on folded_point and folded_evals

--- a/src/whir/batch/verifier.rs
+++ b/src/whir/batch/verifier.rs
@@ -51,7 +51,7 @@ where
         // We first do a pass in which we rederive all the FS challenges
         // Then we will check the algebraic part (so to optimise inversions)
         let parsed_commitment = self.parse_commitment_batch(arthur, num_polys)?;
-        self.batch_verify(arthur, num_polys, points, evals_per_point, parsed_commitment, whir_proof)
+        self.batch_verify_internal(arthur, num_polys, points, evals_per_point, parsed_commitment, whir_proof)
     }
 
     // Different points on each polynomial
@@ -82,10 +82,10 @@ where
         let poly_comb_randomness = super::utils::generate_random_vector_batch_verify(arthur, num_polys)?;
         let (folded_points, folded_evals) = self.parse_unify_sumcheck(arthur, point_per_poly, poly_comb_randomness)?;
 
-        self.batch_verify(arthur, num_polys, &vec![folded_points], &vec![folded_evals.clone()], parsed_commitment, whir_proof)
+        self.batch_verify_internal(arthur, num_polys, &vec![folded_points], &vec![folded_evals.clone()], parsed_commitment, whir_proof)
     }
 
-    fn batch_verify<Arthur>(
+    fn batch_verify_internal<Arthur>(
         &self,
         arthur: &mut Arthur,
         num_polys: usize,
@@ -126,7 +126,7 @@ where
             .chunks_exact(num_polys)
             .map(|answer| compute_dot_product(answer, &random_coeff))
             .collect::<Vec<_>>();
-        let eval_per_point: Vec<F> = evals_per_point.iter().map(|evals| compute_dot_product(evals, &random_coeff)).collect();
+        let eval_per_point = evals_per_point.iter().map(|evals| compute_dot_product(evals, &random_coeff));
 
         let initial_answers: Vec<_> = ood_answers
             .into_iter()

--- a/src/whir/batch/verifier.rs
+++ b/src/whir/batch/verifier.rs
@@ -27,6 +27,7 @@ where
     MerkleConfig: Config<Leaf = [F]>,
     PowStrategy: nimue_pow::PowStrategy,
 {
+    // Same multiple points on each polynomial
     pub fn simple_batch_verify<Arthur>(
         &self,
         arthur: &mut Arthur,
@@ -50,7 +51,57 @@ where
         // We first do a pass in which we rederive all the FS challenges
         // Then we will check the algebraic part (so to optimise inversions)
         let parsed_commitment = self.parse_commitment_batch(arthur, num_polys)?;
+        self.batch_verify(arthur, num_polys, points, evals_per_point, parsed_commitment, whir_proof)
+    }
 
+    // Different points on each polynomial
+    pub fn same_size_batch_verify<Arthur>(
+        &self,
+        arthur: &mut Arthur,
+        num_polys: usize,
+        point_per_poly: &Vec<MultilinearPoint<F>>,
+        eval_per_poly: &Vec<F>, // evaluations of the polys on individual points
+        whir_proof: &WhirProof<MerkleConfig, F>,
+    ) -> ProofResult<MerkleConfig::InnerDigest>
+    where
+        Arthur: FieldChallenges<F>
+            + FieldReader<F>
+            + ByteChallenges
+            + ByteReader
+            + PoWChallenge
+            + DigestReader<MerkleConfig>,
+    {
+        assert_eq!(num_polys, point_per_poly.len());
+        assert_eq!(num_polys, eval_per_poly.len());
+
+        // We first do a pass in which we rederive all the FS challenges
+        // Then we will check the algebraic part (so to optimise inversions)
+        let parsed_commitment = self.parse_commitment_batch(arthur, num_polys)?;
+
+        // parse proof
+        let poly_comb_randomness = super::utils::generate_random_vector_batch_verify(arthur, num_polys)?;
+        let (folded_points, folded_evals) = self.parse_unify_sumcheck(arthur, point_per_poly, poly_comb_randomness)?;
+
+        self.batch_verify(arthur, num_polys, &vec![folded_points], &vec![folded_evals.clone()], parsed_commitment, whir_proof)
+    }
+
+    fn batch_verify<Arthur>(
+        &self,
+        arthur: &mut Arthur,
+        num_polys: usize,
+        points: &Vec<MultilinearPoint<F>>,
+        evals_per_point: &Vec<Vec<F>>,
+        parsed_commitment: ParsedCommitment<F, MerkleConfig::InnerDigest>,
+        whir_proof: &WhirProof<MerkleConfig, F>,
+    ) -> ProofResult<MerkleConfig::InnerDigest>
+    where
+        Arthur: FieldChallenges<F>
+            + FieldReader<F>
+            + ByteChallenges
+            + ByteReader
+            + PoWChallenge
+            + DigestReader<MerkleConfig>,
+    {
         // parse proof
         let compute_dot_product =
             |evals: &[F], coeff: &[F]| -> F { zip_eq(evals, coeff).map(|(a, b)| *a * *b).sum() };
@@ -245,6 +296,56 @@ where
             ood_points,
             ood_answers,
         })
+    }
+
+    fn parse_unify_sumcheck<Arthur>(
+        &self,
+        arthur: &mut Arthur,
+        point_per_poly: &Vec<MultilinearPoint<F>>,
+        poly_comb_randomness: Vec<F>,
+    ) -> ProofResult<(MultilinearPoint<F>, Vec<F>)>
+    where
+        Arthur: FieldReader<F>
+            + FieldChallenges<F>
+            + PoWChallenge
+            + ByteReader
+            + ByteChallenges
+            + DigestReader<MerkleConfig>,
+    {
+        let num_variables = self.params.mv_parameters.num_variables;
+        let mut sumcheck_rounds = Vec::new();
+
+        // Derive combination randomness and first sumcheck polynomial
+        // let [point_comb_randomness_gen]: [F; 1] = arthur.challenge_scalars()?;
+        // let point_comb_randomness = expand_randomness(point_comb_randomness_gen, num_points);
+
+        // Unifying sumcheck
+        sumcheck_rounds.reserve_exact(num_variables);
+        for _ in 0..num_variables {
+            let sumcheck_poly_evals: [F; 3] = arthur.next_scalars()?;
+            let sumcheck_poly = SumcheckPolynomial::new(sumcheck_poly_evals.to_vec(), 1);
+            let [folding_randomness_single] = arthur.challenge_scalars()?;
+            sumcheck_rounds.push((sumcheck_poly, folding_randomness_single));
+
+            if self.params.starting_folding_pow_bits > 0. {
+                arthur.challenge_pow::<PowStrategy>(self.params.starting_folding_pow_bits)?;
+            }
+        }
+        let folded_point = MultilinearPoint(sumcheck_rounds.iter().map(|&(_, r)| r).rev().collect());
+        let folded_eqs: Vec<F> = point_per_poly
+            .iter()
+            .zip(&poly_comb_randomness)
+            .map(|(point, randomness)| *randomness * eq_poly_outside(&point, &folded_point))
+            .collect();
+        let mut folded_evals = vec![F::ZERO; point_per_poly.len()];
+        arthur.fill_next_scalars(&mut folded_evals)?;
+        let sumcheck_claim = sumcheck_rounds[num_variables - 1].0.evaluate_at_point(&MultilinearPoint(vec![sumcheck_rounds[num_variables - 1].1]));
+        let sumcheck_expected: F = folded_evals.iter().zip(&folded_eqs).map(|(eval, eq)| *eval * *eq).sum();
+        if sumcheck_claim != sumcheck_expected {
+            return Err(ProofError::InvalidProof);
+        }
+
+        Ok((folded_point, folded_evals))
     }
 
     fn parse_proof_batch<Arthur>(

--- a/src/whir/batch/verifier.rs
+++ b/src/whir/batch/verifier.rs
@@ -31,7 +31,7 @@ where
         &self,
         arthur: &mut Arthur,
         num_polys: usize,
-        points: &Vec<Vec<F>>,
+        points: &Vec<MultilinearPoint<F>>,
         evals_per_point: &Vec<Vec<F>>,
         whir_proof: &WhirProof<MerkleConfig, F>,
     ) -> ProofResult<MerkleConfig::InnerDigest>
@@ -66,7 +66,7 @@ where
                     self.params.mv_parameters.num_variables,
                 )
             })
-            .chain(points.iter().map(|p| MultilinearPoint(p.to_vec())))
+            .chain(points.clone())
             .collect();
 
         let ood_answers = parsed_commitment

--- a/src/whir/batch/verifier.rs
+++ b/src/whir/batch/verifier.rs
@@ -32,8 +32,8 @@ where
         &self,
         arthur: &mut Arthur,
         num_polys: usize,
-        points: &Vec<MultilinearPoint<F>>,
-        evals_per_point: &Vec<Vec<F>>,
+        points: &[MultilinearPoint<F>],
+        evals_per_point: &[Vec<F>],
         whir_proof: &WhirProof<MerkleConfig, F>,
     ) -> ProofResult<MerkleConfig::InnerDigest>
     where
@@ -89,8 +89,8 @@ where
         &self,
         arthur: &mut Arthur,
         num_polys: usize,
-        points: &Vec<MultilinearPoint<F>>,
-        evals_per_point: &Vec<Vec<F>>,
+        points: &[MultilinearPoint<F>],
+        evals_per_point: &[Vec<F>],
         parsed_commitment: ParsedCommitment<F, MerkleConfig::InnerDigest>,
         whir_proof: &WhirProof<MerkleConfig, F>,
     ) -> ProofResult<MerkleConfig::InnerDigest>
@@ -117,7 +117,7 @@ where
                     self.params.mv_parameters.num_variables,
                 )
             })
-            .chain(points.clone())
+            .chain(points.to_vec())
             .collect();
 
         let ood_answers = parsed_commitment

--- a/src/whir/mod.rs
+++ b/src/whir/mod.rs
@@ -121,7 +121,7 @@ mod tests {
         assert!(verifier.verify(&mut arthur, &statement, &proof).is_ok());
     }
 
-    fn make_whir_batch_things(
+    fn make_whir_batch_things_same_point(
         num_polynomials: usize,
         num_variables: usize,
         num_points: usize,
@@ -189,6 +189,76 @@ mod tests {
         println!("PASSED!");
     }
 
+    fn make_whir_batch_things_diff_point(
+        num_polynomials: usize,
+        num_variables: usize,
+        folding_factor: usize,
+        soundness_type: SoundnessType,
+        pow_bits: usize,
+        fold_type: FoldType,
+    ) {
+        println!(
+            "NP = {num_polynomials}, NV = {num_variables}, FOLD_TYPE = {:?}",
+            fold_type
+        );
+        let num_coeffs = 1 << num_variables;
+
+        let mut rng = ark_std::test_rng();
+        let (leaf_hash_params, two_to_one_params) = merkle_tree::default_config::<F>(&mut rng);
+
+        let mv_params = MultivariateParameters::<F>::new(num_variables);
+
+        let whir_params = WhirParameters::<MerkleConfig, PowStrategy> {
+            initial_statement: true,
+            security_level: 32,
+            pow_bits,
+            folding_factor,
+            leaf_hash_params,
+            two_to_one_params,
+            soundness_type,
+            _pow_parameters: Default::default(),
+            starting_log_inv_rate: 1,
+            fold_optimisation: fold_type,
+        };
+
+        let params = WhirConfig::<F, MerkleConfig, PowStrategy>::new(mv_params, whir_params);
+
+        let polynomials: Vec<CoefficientList<F>> = (0..num_polynomials)
+            .map(|i| CoefficientList::new(vec![F::from((i + 1) as i32); num_coeffs]))
+            .collect();
+
+        let point_per_poly: Vec<MultilinearPoint<F>> = (0..num_polynomials).map(|_| MultilinearPoint::rand(&mut rng, num_variables)).collect();
+        let eval_per_poly: Vec<F> = polynomials.iter().zip(&point_per_poly).map(|(poly, point)|
+            poly.evaluate(point)
+        ).collect();
+
+        let io = IOPattern::<DefaultHash>::new("🌪️")
+            .commit_batch_statement(&params, num_polynomials)
+            .add_whir_unify_proof(&params, num_polynomials)
+            .add_whir_batch_proof(&params, num_polynomials)
+            .clone();
+        let mut merlin = io.to_merlin();
+
+        let committer = Committer::new(params.clone());
+        let witnesses = committer.batch_commit(&mut merlin, &polynomials).unwrap();
+
+        let prover = Prover(params.clone());
+
+        let proof = prover
+            .same_size_batch_prove(&mut merlin, &point_per_poly, &eval_per_poly, &witnesses)
+            .unwrap();
+
+        let verifier = Verifier::new(params);
+        let mut arthur = io.to_arthur(merlin.transcript());
+        verifier
+            .same_size_batch_verify(&mut arthur, num_polynomials, &point_per_poly, &eval_per_poly, &proof)
+            .unwrap();
+        // assert!(verifier
+        //     .same_size_batch_verify(&mut arthur, num_polynomials, &point_per_poly, &eval_per_poly, &proof)
+        //     .is_ok());
+        println!("PASSED!");
+    }
+
     #[test]
     fn test_whir() {
         let folding_factors = [2, 3, 4, 5];
@@ -224,24 +294,46 @@ mod tests {
         //     }
         // }
 
+        // for folding_factor in folding_factors {
+        //     let num_variables = folding_factor..=2 * folding_factor;
+        //     for num_variables in num_variables {
+        //         for fold_type in fold_types {
+        //             for num_points in num_points {
+        //                 for num_polys in num_polys {
+        //                     for soundness_type in soundness_type {
+        //                         for pow_bits in pow_bits {
+        //                             make_whir_batch_things_same_point(
+        //                                 num_polys,
+        //                                 num_variables,
+        //                                 num_points,
+        //                                 folding_factor,
+        //                                 soundness_type,
+        //                                 pow_bits,
+        //                                 fold_type,
+        //                             );
+        //                         }
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //     }
+        // }
+
         for folding_factor in folding_factors {
             let num_variables = folding_factor..=2 * folding_factor;
             for num_variables in num_variables {
                 for fold_type in fold_types {
-                    for num_points in num_points {
-                        for num_polys in num_polys {
-                            for soundness_type in soundness_type {
-                                for pow_bits in pow_bits {
-                                    make_whir_batch_things(
-                                        num_polys,
-                                        num_variables,
-                                        num_points,
-                                        folding_factor,
-                                        soundness_type,
-                                        pow_bits,
-                                        fold_type,
-                                    );
-                                }
+                    for num_polys in num_polys {
+                        for soundness_type in soundness_type {
+                            for pow_bits in pow_bits {
+                                make_whir_batch_things_diff_point(
+                                    num_polys,
+                                    num_variables,
+                                    folding_factor,
+                                    soundness_type,
+                                    pow_bits,
+                                    fold_type,
+                                );
                             }
                         }
                     }

--- a/src/whir/mod.rs
+++ b/src/whir/mod.rs
@@ -272,52 +272,52 @@ mod tests {
         let num_polys = [1, 2, 3];
         let pow_bits = [0, 5, 10];
 
-        // for folding_factor in folding_factors {
-        //     let num_variables = folding_factor - 1..=2 * folding_factor;
-        //     for num_variables in num_variables {
-        //         for fold_type in fold_types {
-        //             for num_points in num_points {
-        //                 for soundness_type in soundness_type {
-        //                     for pow_bits in pow_bits {
-        //                         make_whir_things(
-        //                             num_variables,
-        //                             folding_factor,
-        //                             num_points,
-        //                             soundness_type,
-        //                             pow_bits,
-        //                             fold_type,
-        //                         );
-        //                     }
-        //                 }
-        //             }
-        //         }
-        //     }
-        // }
+        for folding_factor in folding_factors {
+            let num_variables = folding_factor - 1..=2 * folding_factor;
+            for num_variables in num_variables {
+                for fold_type in fold_types {
+                    for num_points in num_points {
+                        for soundness_type in soundness_type {
+                            for pow_bits in pow_bits {
+                                make_whir_things(
+                                    num_variables,
+                                    folding_factor,
+                                    num_points,
+                                    soundness_type,
+                                    pow_bits,
+                                    fold_type,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-        // for folding_factor in folding_factors {
-        //     let num_variables = folding_factor..=2 * folding_factor;
-        //     for num_variables in num_variables {
-        //         for fold_type in fold_types {
-        //             for num_points in num_points {
-        //                 for num_polys in num_polys {
-        //                     for soundness_type in soundness_type {
-        //                         for pow_bits in pow_bits {
-        //                             make_whir_batch_things_same_point(
-        //                                 num_polys,
-        //                                 num_variables,
-        //                                 num_points,
-        //                                 folding_factor,
-        //                                 soundness_type,
-        //                                 pow_bits,
-        //                                 fold_type,
-        //                             );
-        //                         }
-        //                     }
-        //                 }
-        //             }
-        //         }
-        //     }
-        // }
+        for folding_factor in folding_factors {
+            let num_variables = folding_factor..=2 * folding_factor;
+            for num_variables in num_variables {
+                for fold_type in fold_types {
+                    for num_points in num_points {
+                        for num_polys in num_polys {
+                            for soundness_type in soundness_type {
+                                for pow_bits in pow_bits {
+                                    make_whir_batch_things_same_point(
+                                        num_polys,
+                                        num_variables,
+                                        num_points,
+                                        folding_factor,
+                                        soundness_type,
+                                        pow_bits,
+                                        fold_type,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         for folding_factor in folding_factors {
             let num_variables = folding_factor..=2 * folding_factor;

--- a/src/whir/mod.rs
+++ b/src/whir/mod.rs
@@ -165,7 +165,6 @@ mod tests {
             .iter()
             .map(|poly| poly.evaluate(point))
             .collect()).collect();
-        let points: Vec<Vec<F>> = points.into_iter().map(|point| point.0).collect();
 
         let io = IOPattern::<DefaultHash>::new("🌪️")
             .commit_batch_statement(&params, num_polynomials)


### PR DESCRIPTION
Finished batched openings on polynomials of the same size on different points.

Main contributions:
1. Update the original simple_batch_prove to support multiple (or 0) points evaluated across all polynomials.
2. A new sumcheck protocol in `sumcheck/prover_batched` and `sumcheck/prover_not_skipping_batched` which uses a separate Eq polynomial for each point.
3. New `same_size_batch_prove` and `same_size_batch_verify` which first runs the new "unify" sumcheck to obtain the evaluation of all polynomials on the same point, and then perform regular WHIR operations.
4. New tests: `make_whir_batch_things_diff_point`.

Remaining Issues:
1. One can imagine the support of multiple same / different opening points on each polynomial, not sure if this would be useful
2. Existing ceno interface of `prove_with_merlin_simple_batch`, etc. now requires copying the point and eval. This problem can be mitigated by making modifications in ceno.
3. Ceno interface for opening different points is not implemented.